### PR TITLE
Bump from reactor 2.3.5.RELEASE to 3.5.0

### DIFF
--- a/examples/src/main/java/io/dapr/examples/OpenTelemetryConfig.java
+++ b/examples/src/main/java/io/dapr/examples/OpenTelemetryConfig.java
@@ -89,7 +89,7 @@ public class OpenTelemetryConfig {
    * Converts current OpenTelemetry's context into Reactor's context.
    * @return Reactor's context.
    */
-  public static reactor.util.context.Context getReactorContext() {
+  public static reactor.util.context.ContextView getReactorContext() {
     return getReactorContext(Context.current());
   }
 

--- a/examples/src/main/java/io/dapr/examples/pubsub/BulkPublisher.java
+++ b/examples/src/main/java/io/dapr/examples/pubsub/BulkPublisher.java
@@ -71,7 +71,7 @@ public class BulkPublisher {
           System.out.println("Going to publish message : " + message);
         }
         BulkPublishResponse<?> res = client.publishEvents(PUBSUB_NAME, TOPIC_NAME, "text/plain", messages)
-            .subscriberContext(getReactorContext()).block();
+            .contextWrite(getReactorContext()).block();
         System.out.println("Published the set of messages in a single call to Dapr");
         if (res != null) {
           if (res.getFailedEntries().size() > 0) {

--- a/examples/src/main/java/io/dapr/examples/pubsub/PublisherWithTracing.java
+++ b/examples/src/main/java/io/dapr/examples/pubsub/PublisherWithTracing.java
@@ -63,7 +63,7 @@ public class PublisherWithTracing {
           client.publishEvent(
               PUBSUB_NAME,
               TOPIC_NAME,
-              message).subscriberContext(getReactorContext()).block();
+              message).contextWrite(getReactorContext()).block();
           System.out.println("Published message: " + message);
 
           try {

--- a/examples/src/main/java/io/dapr/examples/tracing/InvokeClient.java
+++ b/examples/src/main/java/io/dapr/examples/tracing/InvokeClient.java
@@ -67,7 +67,7 @@ public class InvokeClient {
                 InvokeMethodRequest sleepRequest = new InvokeMethodRequest(SERVICE_APP_ID, "proxy_sleep")
                     .setHttpExtension(HttpExtension.POST);
                 return client.invokeMethod(sleepRequest, TypeRef.get(Void.class));
-              }).subscriberContext(getReactorContext()).block();
+              }).contextWrite(getReactorContext()).block();
         }
       }
     }

--- a/examples/src/main/java/io/dapr/examples/tracing/TracingDemoMiddleServiceController.java
+++ b/examples/src/main/java/io/dapr/examples/tracing/TracingDemoMiddleServiceController.java
@@ -58,7 +58,7 @@ public class TracingDemoMiddleServiceController {
     InvokeMethodRequest request = new InvokeMethodRequest(INVOKE_APP_ID, "echo")
         .setBody(body)
         .setHttpExtension(HttpExtension.POST);
-    return client.invokeMethod(request, TypeRef.get(byte[].class)).subscriberContext(getReactorContext(context));
+    return client.invokeMethod(request, TypeRef.get(byte[].class)).contextWrite(getReactorContext(context));
   }
 
   /**
@@ -71,7 +71,7 @@ public class TracingDemoMiddleServiceController {
   public Mono<Void> sleep(@RequestAttribute(name = "opentelemetry-context") Context context) {
     InvokeMethodRequest request = new InvokeMethodRequest(INVOKE_APP_ID, "sleep")
         .setHttpExtension(HttpExtension.POST);
-    return client.invokeMethod(request, TypeRef.get(byte[].class)).subscriberContext(getReactorContext(context)).then();
+    return client.invokeMethod(request, TypeRef.get(byte[].class)).contextWrite(getReactorContext(context)).then();
   }
 
 }

--- a/sdk-actors/src/main/java/io/dapr/actors/client/DaprGrpcClient.java
+++ b/sdk-actors/src/main/java/io/dapr/actors/client/DaprGrpcClient.java
@@ -29,7 +29,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.stub.StreamObserver;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoSink;
-import reactor.util.context.Context;
+import reactor.util.context.ContextView;
 
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
@@ -65,7 +65,7 @@ class DaprGrpcClient implements DaprClient {
             .setMethod(methodName)
             .setData(jsonPayload == null ? ByteString.EMPTY : ByteString.copyFrom(jsonPayload))
             .build();
-    return Mono.subscriberContext().flatMap(
+    return Mono.deferContextual(
         context -> this.<DaprProtos.InvokeActorResponse>createMono(
             it -> intercept(context, client).invokeActor(req, it)
         )
@@ -109,7 +109,7 @@ class DaprGrpcClient implements DaprClient {
    * @param client GRPC client for Dapr.
    * @return Client after adding interceptors.
    */
-  private static DaprGrpc.DaprStub intercept(Context context, DaprGrpc.DaprStub client) {
+  private static DaprGrpc.DaprStub intercept(ContextView context, DaprGrpc.DaprStub client) {
     return GrpcWrapper.intercept(context, client);
   }
 

--- a/sdk-tests/pom.xml
+++ b/sdk-tests/pom.xml
@@ -120,7 +120,7 @@
       <dependency>
           <groupId>io.projectreactor</groupId>
           <artifactId>reactor-core</artifactId>
-          <version>3.3.11.RELEASE</version>
+          <version>3.5.0</version>
           <scope>test</scope>
       </dependency>
     <dependency>

--- a/sdk-tests/src/test/java/io/dapr/it/methodinvoke/grpc/MethodInvokeIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/methodinvoke/grpc/MethodInvokeIT.java
@@ -101,7 +101,7 @@ public class MethodInvokeIT extends BaseIT {
                     .block(Duration.ofMillis(10))).getMessage();
             long delay = System.currentTimeMillis() - started;
             assertTrue(delay <= 500);  // 500 ms is a reasonable delay if the request timed out.
-            assertEquals("Timeout on blocking read for 10 MILLISECONDS", message);
+            assertEquals("Timeout on blocking read for 10000000 NANOSECONDS", message);
         }
     }
 

--- a/sdk-tests/src/test/java/io/dapr/it/methodinvoke/http/MethodInvokeIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/methodinvoke/http/MethodInvokeIT.java
@@ -118,7 +118,7 @@ public class MethodInvokeIT extends BaseIT {
             }).getMessage();
             long delay = System.currentTimeMillis() - started;
             assertTrue(delay <= 200);  // 200 ms is a reasonable delay if the request timed out.
-            assertEquals("Timeout on blocking read for 10 MILLISECONDS", message);
+            assertEquals("Timeout on blocking read for 10000000 NANOSECONDS", message);
         }
     }
 

--- a/sdk-tests/src/test/java/io/dapr/it/tracing/grpc/TracingIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/tracing/grpc/TracingIT.java
@@ -79,7 +79,7 @@ public class TracingIT extends BaseIT {
             try (Scope scope = span.makeCurrent()) {
                 SleepRequest req = SleepRequest.newBuilder().setSeconds(1).build();
                 client.invokeMethod(daprRun.getAppName(), "sleepOverGRPC", req.toByteArray(), HttpExtension.POST)
-                    .subscriberContext(getReactorContext())
+                    .contextWrite(getReactorContext())
                     .block();
             }
         }

--- a/sdk-tests/src/test/java/io/dapr/it/tracing/http/TracingIT.java
+++ b/sdk-tests/src/test/java/io/dapr/it/tracing/http/TracingIT.java
@@ -76,7 +76,7 @@ public class TracingIT extends BaseIT {
         try (DaprClient client = new DaprClientBuilder().build()) {
             try (Scope scope = span.makeCurrent()) {
                 client.invokeMethod(daprRun.getAppName(), "sleep", 1, HttpExtension.POST)
-                    .subscriberContext(getReactorContext())
+                    .contextWrite(getReactorContext())
                     .block();
             }
         }

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-core</artifactId>
-      <version>3.3.11.RELEASE</version>
+      <version>3.5.0</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>

--- a/sdk/src/main/java/io/dapr/internal/opencensus/GrpcWrapper.java
+++ b/sdk/src/main/java/io/dapr/internal/opencensus/GrpcWrapper.java
@@ -23,9 +23,9 @@ import io.grpc.ForwardingClientCall;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import reactor.util.context.Context;
+import reactor.util.context.ContextView;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -61,7 +61,7 @@ public final class GrpcWrapper {
    * @param client GRPC client for Dapr.
    * @return Client after adding interceptors.
    */
-  public static DaprGrpc.DaprStub intercept(final Context context, DaprGrpc.DaprStub client) {
+  public static DaprGrpc.DaprStub intercept(final ContextView context, DaprGrpc.DaprStub client) {
     ClientInterceptor interceptor = new ClientInterceptor() {
       @Override
       public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(

--- a/sdk/src/test/java/io/dapr/client/DaprClientGrpcTelemetryTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientGrpcTelemetryTest.java
@@ -42,6 +42,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import reactor.util.context.ContextView;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -189,7 +190,7 @@ public class DaprClientGrpcTelemetryTest {
         .setBody("request")
         .setHttpExtension(HttpExtension.NONE);
     Mono<Void> result = this.client.invokeMethod(req, TypeRef.get(Void.class))
-        .subscriberContext(it -> it.putAll(contextCopy == null ? Context.empty() : contextCopy));
+        .contextWrite(it -> it.putAll(contextCopy == null ? (ContextView) Context.empty() : contextCopy));
     result.block();
   }
 

--- a/sdk/src/test/java/io/dapr/client/DaprClientHttpTest.java
+++ b/sdk/src/test/java/io/dapr/client/DaprClientHttpTest.java
@@ -53,6 +53,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import reactor.util.context.ContextView;
 
 import static io.dapr.utils.TestUtils.assertThrowsDaprException;
 import static io.dapr.utils.TestUtils.findFreePort;
@@ -422,7 +423,7 @@ public class DaprClientHttpTest {
         .setBody("request")
         .setHttpExtension(HttpExtension.POST);
     Mono<Void> result = daprClientHttp.invokeMethod(req, TypeRef.get(Void.class))
-        .subscriberContext(it -> it.putAll(context));
+        .contextWrite(it -> it.putAll((ContextView) context));
     result.block();
   }
 

--- a/sdk/src/test/java/io/dapr/client/DaprHttpStub.java
+++ b/sdk/src/test/java/io/dapr/client/DaprHttpStub.java
@@ -14,7 +14,7 @@ limitations under the License.
 package io.dapr.client;
 
 import reactor.core.publisher.Mono;
-import reactor.util.context.Context;
+import reactor.util.context.ContextView;
 
 import java.util.List;
 import java.util.Map;
@@ -45,7 +45,7 @@ public class DaprHttpStub extends DaprHttp {
         String[] pathSegments,
         Map<String, List<String>> urlParameters,
         Map<String, String> headers,
-        Context context) {
+        ContextView context) {
         return Mono.empty();
     }
 
@@ -58,7 +58,7 @@ public class DaprHttpStub extends DaprHttp {
         Map<String, List<String>> urlParameters,
         String content,
         Map<String, String> headers,
-        Context context) {
+        ContextView context) {
         return Mono.empty();
     }
 
@@ -71,7 +71,7 @@ public class DaprHttpStub extends DaprHttp {
         Map<String, List<String>> urlParameters,
         byte[] content,
         Map<String, String> headers,
-        Context context) {
+        ContextView context) {
         return Mono.empty();
     }
 


### PR DESCRIPTION
Signed-off-by: Sergio <champel@gmail.com>

# Description

- Upgraded reactor-core from 2.3.5.RELEASE to 2.7.8.
- Adapt the integration tests

## Issue reference

Related Issue:  #815

Note: This PR prepares for upgrading to Spring Boot 3. Upgrade spring boot to 2.7 is also needed.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
